### PR TITLE
Split by space and tab & coffeescript dependancy

### DIFF
--- a/lib/diff_file.js
+++ b/lib/diff_file.js
@@ -3,7 +3,7 @@
 
   module.exports = DiffFile = (function() {
     function DiffFile(firstLine) {
-      this.name = firstLine.split(' ')[1];
+      this.name = firstLine.split(/\s/g)[1];
       this.lines = [];
     }
 

--- a/lib/diff_file.js
+++ b/lib/diff_file.js
@@ -9,13 +9,13 @@
 
     DiffFile.prototype.setIndex = function(indexLine) {
       var match;
-      match = indexLine.split(' ')[2].replace(')', '');
+      match = indexLine.split(/\s/g)[2].replace(')', '');
       return this.from = match;
     };
 
     DiffFile.prototype.finishHeaderParse = function(line) {
       var match;
-      match = line.split(' ')[2].replace(')', '');
+      match = line.split(/\s/g)[2].replace(')', '');
       this.to = match;
       return this.headerParsed = true;
     };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "jade": ">=0.34.1"
+    "jade": ">=0.34.1",
+    "coffee-script": "^1.12.7"
   },
   "bin": {
     "diff2html": "./bin/diff2html"


### PR DESCRIPTION
Some svn instances return tab deliminated rather than space deliminated diffs.

This allows both.